### PR TITLE
CI: Use public runners / limit workflow runs

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -20,6 +20,13 @@ jobs:
           # Nix Flakes doesn't work on shallow clones
           fetch-depth: 0
 
+      - uses: cachix/install-nix-action@v13
+        with:
+          install_url: https://nixos-nix-install-tests.cachix.org/serve/lb41az54kzk6j12p81br4bczary7m145/install
+          install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
+          extra_nix_config: |
+            experimental-features = nix-command flakes ca-references
+
       - name: Check that node-env is up-to-date
         run: |
           nix run '.#update-package-lock'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -11,7 +11,6 @@ on:
 jobs:
   check:
     name: Run checks.
-    runs-on: [ self-hosted ]
     env:
       GC_DONT_GC: 1
     steps:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -11,6 +11,7 @@ on:
 jobs:
   check:
     name: Run checks.
+    runs-on: ubuntu-latest
     env:
       GC_DONT_GC: 1
     steps:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,6 +1,12 @@
 name: 'Checks'
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
 
 jobs:
   check:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,6 +11,7 @@ on:
 jobs:
   check:
     name: Run our Action
+    runs-on: ubuntu-latest
     env:
       GC_DONT_GC: 1
     steps:
@@ -52,6 +53,7 @@ jobs:
   build:
     name: Build bundled action
     if: github.event_name == 'push'
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -77,6 +79,7 @@ jobs:
 
   coverage:
     if: github.event_name == 'push'
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,6 +1,12 @@
 name: 'CI'
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
 
 jobs:
   check:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,6 +20,13 @@ jobs:
           # Nix Flakes doesn't work on shallow clones
           fetch-depth: 0
 
+      - uses: cachix/install-nix-action@v13
+        with:
+          install_url: https://nixos-nix-install-tests.cachix.org/serve/lb41az54kzk6j12p81br4bczary7m145/install
+          install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
+          extra_nix_config: |
+            experimental-features = nix-command flakes ca-references
+
       - name: Run Action
         uses: ./
         with:
@@ -52,6 +59,13 @@ jobs:
           # Nix Flakes doesn't work on shallow clones
           fetch-depth: 0
 
+      - uses: cachix/install-nix-action@v13
+        with:
+          install_url: https://nixos-nix-install-tests.cachix.org/serve/lb41az54kzk6j12p81br4bczary7m145/install
+          install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
+          extra_nix_config: |
+            experimental-features = nix-command flakes ca-references
+
       - name: Install job dependencies
         uses: ./
         with:
@@ -69,6 +83,13 @@ jobs:
         with:
           # Nix Flakes doesn't work on shallow clones
           fetch-depth: 0
+
+      - uses: cachix/install-nix-action@v13
+        with:
+          install_url: https://nixos-nix-install-tests.cachix.org/serve/lb41az54kzk6j12p81br4bczary7m145/install
+          install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
+          extra_nix_config: |
+            experimental-features = nix-command flakes ca-references
 
       - name: Run tests with coverage
         run: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,7 +11,6 @@ on:
 jobs:
   check:
     name: Run our Action
-    runs-on: [ self-hosted ]
     env:
       GC_DONT_GC: 1
     steps:
@@ -46,7 +45,6 @@ jobs:
   build:
     name: Build bundled action
     if: github.event_name == 'push'
-    runs-on: [ self-hosted, default ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -65,7 +63,6 @@ jobs:
 
   coverage:
     if: github.event_name == 'push'
-    runs-on: [ self-hosted, default ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
* Use public runners from GitHub to run the workflows
* Run workflows only for open PRs against `main` and for pushes to `main` (e.g., after merging a PR into `main`)

It would be best to run the workflows on a self-hosted runner but—to the best of our knowledge—there's no secure option available to do that for a public repository.