### PR TITLE
Revert "flake: workaround for broken pyOpenSSL on aarch64-darwin"

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,12 +7,7 @@
   outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs = import nixpkgs {
-          inherit system;
-          # Temporarily required until a bug on pyOpenSSL is resolved for aarch64-darwin
-          # https://github.com/NixOS/nixpkgs/pull/172397
-          config.allowBroken = true;
-        };
+        pkgs = import nixpkgs { inherit system; };
         packageJson = builtins.fromJSON (builtins.readFile ./package.json);
         nodejs = pkgs.nodejs-16_x;
         nodeEnv = pkgs.callPackage ./node-env { inherit nodejs; };


### PR DESCRIPTION
This reverts commit 1a0f0ec0e5e2706641e5524ac3bfd514798941c8.

Adapt as soon as https://github.com/NixOS/nixpkgs/pull/172397 is resolved properly.